### PR TITLE
Mantid versions: latest & nightly

### DIFF
--- a/autoreduce_frontend/autoreduce_webapp/fixtures/software_fixture.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/software_fixture.json
@@ -9,7 +9,7 @@
     },
     {
         "model": "reduction_viewer.software",
-        "pk": 1,
+        "pk": 2,
         "fields": {
             "name": "Mantid",
             "version": "nightly"

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/software_fixture.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/software_fixture.json
@@ -4,7 +4,15 @@
         "pk": 1,
         "fields": {
             "name": "Mantid",
-            "version": "6.2.0"
+            "version": "latest"
+        }
+    },
+    {
+        "model": "reduction_viewer.software",
+        "pk": 1,
+        "fields": {
+            "name": "Mantid",
+            "version": "nightly"
         }
     }
 ]


### PR DESCRIPTION
### Summary of work
Update software fixture to be populated with Mantid latest and Mantid nightly.

This fixture is used to populate the database (local and in production) with the available software versions (then used to populate frontend drop-down software select)