### PR TITLE
Switch from Gunicorn to Django Hurricane

### DIFF
--- a/autoreduce_frontend/autoreduce_webapp/settings.py
+++ b/autoreduce_frontend/autoreduce_webapp/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
     'django_filters',
     'crispy_forms',
     'django_tables2',
+    'hurricane',
 ]
 
 if DEBUG and DEBUG_TOOLBAR_AVAILABLE:

--- a/container/webapp.D
+++ b/container/webapp.D
@@ -13,4 +13,4 @@ RUN chown isisautoreduce:isisautoreduce /var/www/api/
 USER isisautoreduce
 
 EXPOSE 8000
-CMD ["autoreduce-webapp-manage", "serve", "--port", "8000"]
+CMD ["autoreduce-webapp-manage", "serve", "--port", "8000", "--probe-port", "8004"]

--- a/container/webapp.D
+++ b/container/webapp.D
@@ -1,7 +1,5 @@
 FROM ghcr.io/autoreduction/base
 
-RUN python3 -m pip install --user --no-cache-dir gunicorn
-
 # Installs frontend from your local repository
 ADD . .
 RUN python3 -m pip install --user --no-cache-dir .
@@ -15,4 +13,4 @@ RUN chown isisautoreduce:isisautoreduce /var/www/api/
 USER isisautoreduce
 
 EXPOSE 8000
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "4", "autoreduce_frontend.autoreduce_webapp.wsgi"]
+CMD ["autoreduce-webapp-manage", "serve", "--port", "8000"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "django-tables2==2.4.1",
     "requests==2.27.1",
     "httpagentparser==1.9.2",
+    "django-hurricane",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Summary of work
Replace Gunicorn with [Hurricane](https://github.com/django-hurricane/django-hurricane) for hosting the web server.

Hurricane includes built-in Probe endpoints, which will be useful for including livenessProbes and readinessProbes in the Kubernetes deployments of the frontend and rest-api.
