### PR TITLE
Switch to tox (AR-1667)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,9 +38,11 @@ jobs:
       - name: Wait until the Selenium instance is ready
         run: until nc -w 1 127.0.0.1 4444; do sleep 1; done
 
-      - name: Run tests
-        run: |
-          SELENIUM_REMOTE=1 RUNNING_VIA_PYTEST=true pytest autoreduce_frontend --cov-report=xml --cov=autoreduce_frontend --ignore=autoreduce_frontend/selenium_tests/tests/integration --showlocals -v
+      - name: Install Tox
+        run: python -m pip install tox tox-gh-actions
+
+      - name: Run Selenium Pages tests with tox
+        run: tox -e pages
 
       - uses: codecov/codecov-action@v3
         with:
@@ -113,10 +115,11 @@ jobs:
       - name: Wait until the Selenium instance is ready
         run: until nc -w 1 127.0.0.1 4444; do sleep 1; done
 
-      - name: Run tests
-        run: |
-          env
-          SELENIUM_REMOTE=1 RUNNING_VIA_PYTEST=true TESTING_MYSQL_DB=true pytest autoreduce_frontend/selenium_tests/tests/integration --cov-report=xml --cov=autoreduce_frontend --showlocals -v
+      - name: Install Tox
+        run: python -m pip install tox tox-gh-actions
+
+      - name: Run Selenium Integration tests with tox
+        run: tox -e integration
 
       - uses: codecov/codecov-action@v2
         with:
@@ -194,6 +197,8 @@ jobs:
         with:
           package_name: autoreduce_frontend
 
-      - uses: autoreduction/autoreduce-actions/code_inspection@main
-        with:
-          package_name: autoreduce_frontend
+      - name: Install Tox
+        run: python -m pip install tox tox-gh-actions
+
+      - name: Run code inspection with tox
+        run: tox -e code_inspection

--- a/.gitignore
+++ b/.gitignore
@@ -1,65 +1,256 @@
-# Ignore IDE files
-.idea/*
-*/target/**
-.pytest_cache/
+# Created by https://www.toptal.com/developers/gitignore/api/python,django
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,django
 
-
-# Ignore complied python
-*.pyc
-
-# Ignore log data
+### Django ###
 *.log
-logs/
+*.pot
+*.pyc
+__pycache__/
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+media
 
-# *.out
+# If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
+# in your Git repository. Update and uncomment the following line accordingly.
+# <django-project-name>/staticfiles/
 
-# Ignore credentials files
-credentials.ini
+### Django.Python Stack ###
+# Byte-compiled / optimized / DLL files
+*.py[cod]
+*$py.class
 
-# Ignore distutils installation
-dist/
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
 build/
-
-# Ignore virtual environment
-venv/
-venv3/
-venv36/
-venv37/
-
-# Ignore pip install installation
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
 *.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
 
-# This is generated from a template so should be ignored to force regeneration
-apache_django_wsgi.conf
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 
-# Ignore coverage logs
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
+.coverage.*
+.cache
+nosetests.xml
 coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
 
-# Include the coverage configuration file
-!.coveragerc
+# Translations
+*.mo
 
-# Ignore site.retry from Ansible
-site.retry
-vault.yml
+# Django stuff:
 
-.DS_Store
+# Flask stuff:
+instance/
+.webassets-cache
 
-# Ignore downloaded graphs
-!autoreduce_frontend/static/graphs
-!autoreduce_frontend/static/graphs/.keep
+# Scrapy stuff:
+.scrapy
 
-# Ignore collected staticfiles
-autoreduce_frontend/staticfiles
+# Sphinx documentation
+docs/_build/
 
-.vscode/settings.json
+# PyBuilder
+.pybuilder/
+target/
 
-# ignore sqlite3 db files
-**/sqlite3*.db*
+# Jupyter Notebook
+.ipynb_checkpoints
 
-# folders that get created from tests
-reduced-data*/
-data-archive*/
-test-archive*/
+# IPython
+profile_default/
+ipython_config.py
 
-autoreduce.code-workspace
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+
+# C extensions
+
+# Distribution / packaging
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+
+# Installer logs
+
+# Unit test / coverage reports
+
+# Translations
+
+# Django stuff:
+
+# Flask stuff:
+
+# Scrapy stuff:
+
+# Sphinx documentation
+
+# PyBuilder
+
+# Jupyter Notebook
+
+# IPython
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+
+# Celery stuff
+
+# SageMath parsed files
+
+# Environments
+
+# Spyder project settings
+
+# Rope project settings
+
+# mkdocs documentation
+
+# mypy
+
+# Pyre type checker
+
+# pytype static type analyzer
+
+# Cython debug symbols
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+
+# End of https://www.toptal.com/developers/gitignore/api/python,django

--- a/autoreduce_frontend/autoreduce_webapp/icat_communication.py
+++ b/autoreduce_frontend/autoreduce_webapp/icat_communication.py
@@ -25,6 +25,8 @@ class ICATCommunication:
     Handles communication with the ICAT service
     """
 
+    # pylint: disable=unsubscriptable-object
+
     def __init__(self, **kwargs):
         if 'URL' not in kwargs:
             kwargs['URL'] = ICAT['URL']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     "gunicorn",
     "mysqlclient==2.1.0",
     "selenium",
+    "parameterized==0.8.1",
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist =
     yapf
     vulture
 isolated_build = True
+requires =
+    setuptools == 57.5.0
 
 [gh-actions]
 python =
@@ -14,6 +16,7 @@ python =
 [testenv]
 description =
     Common environment.
+#install_command = pip uninstall -y setuptools && pip install setuptools==57.5.0 && pip install .
 passenv = *
 setenv =
     PY_COLORS=1

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ python =
 [testenv]
 description =
     Common environment.
+deps =
+    setuptools < 58.0.0
 passenv = *
 setenv =
     PY_COLORS=1
@@ -29,7 +31,7 @@ setenv =
     RUNNING_VIA_PYTEST=true
     PY_COLORS=1
 deps =
-    setuptools < 58.0.0
+    {[testenv]deps}
     pytest
     pytest-cov
     pytest-django
@@ -48,6 +50,7 @@ setenv =
     TESTING_MYSQL_DB=true
     PY_COLORS=1
 deps =
+    {[testenv]deps}
     pytest
     pytest-cov
     pytest-django

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,103 @@
+[tox]
+envlist =
+    pages
+    integration
+    pylint
+    yapf
+    vulture
+isolated_build = True
+
+[gh-actions]
+python =
+    3.8: py38
+
+[testenv]
+description =
+    Common environment.
+passenv = *
+setenv =
+    PY_COLORS=1
+extras =
+    dev
+
+[testenv:pages]
+description =
+    Run Selenium Pages tests.
+skip_install = False
+setenv =
+    SELENIUM_REMOTE=1
+    RUNNING_VIA_PYTEST=true
+    PY_COLORS=1
+deps =
+    pytest
+    pytest-cov
+    pytest-django
+commands =
+    pytest {envsitepackagesdir}/autoreduce_frontend --cov-report=xml --cov={envsitepackagesdir}/autoreduce_frontend \
+    --ignore={envsitepackagesdir}/autoreduce_frontend/selenium_tests/tests/integration --showlocals -v
+
+[testenv:integration]
+description =
+    Run Selenium Integration tests.
+skip_install = False
+setenv =
+    SELENIUM_REMOTE=1
+    RUNNING_VIA_PYTEST=true
+    TESTING_MYSQL_DB=true
+    PY_COLORS=1
+deps =
+    pytest
+    pytest-cov
+    pytest-django
+commands =
+    pytest {envsitepackagesdir}/autoreduce_frontend/selenium_tests/tests/integration \
+    --cov-report=xml --cov={envsitepackagesdir}/autoreduce_frontend --showlocals -v
+
+[testenv:pylint]
+description =
+    Run pylint style checks.
+skip_install = False
+setenv =
+    PYTHONPATH={envsitepackagesdir}/autoreduce_frontend
+deps =
+    pylint==2.14.5
+    pylint-django==2.5.3
+commands =
+    pylint --version
+    pylint {envsitepackagesdir}/autoreduce_frontend --output-format=colorized
+
+[testenv:yapf]
+description =
+    Run yapf style checks.
+skip_install = True
+deps =
+    yapf==0.32.0
+    toml
+commands =
+    yapf --version
+    yapf --parallel --diff --recursive autoreduce_frontend
+
+[testenv:vulture]
+description =
+    Run vulture checks.
+skip_install = True
+deps =
+    vulture==2.5
+commands =
+    vulture --version
+    vulture --min-confidence 90 autoreduce_frontend
+
+[testenv:code_inspection]
+description =
+    Run code inspection checks.
+skip_install = False
+setenv =
+    PYTHONPATH={envsitepackagesdir}/autoreduce_frontend
+deps =
+    {[testenv:pylint]deps}
+    {[testenv:yapf]deps}
+    {[testenv:vulture]deps}
+commands =
+    {[testenv:pylint]commands}
+    {[testenv:yapf]commands}
+    {[testenv:vulture]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,8 @@ python =
 [testenv]
 description =
     Common environment.
-install_command = pip uninstall -y setuptools && pip install setuptools==57.5.0 && pip install .
+deps =
+    setuptools < 58.0.0
 passenv = *
 setenv =
     PY_COLORS=1
@@ -36,6 +37,7 @@ deps =
     pytest-cov
     pytest-django
 commands =
+    pip list
     pytest {envsitepackagesdir}/autoreduce_frontend --cov-report=xml --cov={envsitepackagesdir}/autoreduce_frontend \
     --ignore={envsitepackagesdir}/autoreduce_frontend/selenium_tests/tests/integration --showlocals -v
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ python =
 [testenv]
 description =
     Common environment.
-#install_command = pip uninstall -y setuptools && pip install setuptools==57.5.0 && pip install .
+install_command = pip uninstall -y setuptools && pip install setuptools==57.5.0 && pip install .
 passenv = *
 setenv =
     PY_COLORS=1

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,6 @@ envlist =
     yapf
     vulture
 isolated_build = True
-requires =
-    setuptools == 57.5.0
 
 [gh-actions]
 python =
@@ -16,8 +14,6 @@ python =
 [testenv]
 description =
     Common environment.
-deps =
-    setuptools < 58.0.0
 passenv = *
 setenv =
     PY_COLORS=1
@@ -33,6 +29,7 @@ setenv =
     RUNNING_VIA_PYTEST=true
     PY_COLORS=1
 deps =
+    setuptools < 58.0.0
     pytest
     pytest-cov
     pytest-django


### PR DESCRIPTION
### Summary of work

- Use Tox for tests
- Update .gitignore to a more generic one (includes things for tox etc.)
- Add `["parameterized==0.8.1"] `  as dev dependencies (required for running tests)